### PR TITLE
Plugin install from symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # wp-cli
-Provide WordPress WPCLI extended features for EPFL needs
+Provide WordPress WPCLI extended features for EPFL's needs

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "epfl-idevelop/wp-cli",
+    "description": "An extension to existing WPCLI commands to fit EPFL's needs",
+    "type": "wp-cli-package",
+    "homepage": "https://github.com/epfli-develop/wp-cli",
+    "support": {
+        "issues": "https://github.com/epfl-idevelop/wp-cli/issues"
+    },
+    "require": {
+       "wp-cli/wp-cli": "~1.5.0",
+       "wp-cli/extension-command": "^1.1 || ^2"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Lucien Chaboudez",
+            "email": "lucien.chaboudez@epfl.ch"
+        }
+    ],
+  "autoload": {
+    "files": [ "src/epfl-wp-cli.php" ]
+  },
+    "require-dev": {
+        "behat/behat": "~2.5"
+    }
+}

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -50,7 +50,6 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
 
                 /* If plugin is available in WP image */
                 $wp_image_plugin_folder = $this->PLUGIN_FOLDER . $plugin_name;
-                /* TODO: improve this to check PHP headers instead of folder/file name */
                 if(file_exists($wp_image_plugin_folder))
                 {
                     /* Creating symlink to "simulate" plugin installation */

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -7,7 +7,7 @@
  * @version 1.0.0
  */
 
-namespace EPFL_WPCLI;
+namespace EPFL_WP_CLI;
 
 if ( version_compare( PHP_VERSION, '5.5', '<' ) ) {
     \WP_CLI::error( sprintf( 'This WP-CLI package requires PHP version %s or higher.', '5.5' ) );
@@ -36,7 +36,6 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
             /* If an URL or a ZIP file has been given, we can't handle it so we call parent method */
             if(preg_match('/(^http|\.zip$)/', $plugin_name)==1)
             {
-                /* Calling parent fuction to process to installation */
                 parent::install($args, $assoc_args);
                 return;
             }
@@ -93,4 +92,4 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
 }
 
 /* We override existing commands with extended one */
-\WP_CLI::add_command( 'plugin', 'EPFL_WPCLI\EPFL_Plugin_Command' );
+\WP_CLI::add_command( 'plugin', 'EPFL_WP_CLI\EPFL_Plugin_Command' );

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * EPFL WPCLI extended commands
+ *
+ * @author  Lucien Chaboudez <lucien.chaboudez@epfl.ch>
+ * @package epfl-idevelop/wp-cli
+ * @version 1.0.0
+ */
+
+namespace EPFL_WPCLI;
+
+if ( version_compare( PHP_VERSION, '5.5', '<' ) ) {
+    \WP_CLI::error( sprintf( 'This WP-CLI package requires PHP version %s or higher.', '5.5' ) );
+}
+if ( version_compare( WP_CLI_VERSION, '1.5.0', '<' ) ) {
+    \WP_CLI::error( sprintf( 'This WP-CLI package requires WP-CLI version %s or higher. Please visit %s', '1.5.0', 'https://wp-cli.org/#updating' ) );
+}
+
+/**
+ * Manage plugin installation with symlinks
+ *
+ * Parent class can be found here:
+ * https://github.com/wp-cli/extension-command/blob/master/src/Plugin_Command.php
+ *
+ */
+class EPFL_Plugin_Command extends \Plugin_Command  {
+
+    var $PLUGIN_FOLDER = "/wp/wp-content/plugins/";
+
+    /* Override existing install function*/
+    public function install( $args, $assoc_args ) {
+
+        /* Looping through plugins to install */
+        foreach($args as $plugin_name)
+        {
+            /* If an URL or a ZIP file has been given, we can't handle it so we call parent method */
+            if(preg_match('/(^http|\.zip$)/', $plugin_name)==1)
+            {
+                /* Calling parent fuction to process to installation */
+                parent::install($args, $assoc_args);
+                return;
+            }
+
+            /* Looking if plugin is already installed. We cannot call "parent::is_installed()" because
+             it just halts process with 1 or 0 to tell plugin installation status... */
+            $response = \WP_CLI::launch_self( 'plugin is-installed', array($plugin_name), array(), false, true );
+
+            /* If plugin is not installed */
+            if($response->return_code == 1)
+            {
+
+                /* If plugin is available in WP image */
+                $wp_image_plugin_folder = $this->PLUGIN_FOLDER . $plugin_name;
+                /* TODO: improve this to check PHP headers instead of folder/file name */
+                if(file_exists($wp_image_plugin_folder))
+                {
+                    /* Creating symlink to "simulate" plugin installation */
+                    if(symlink($wp_image_plugin_folder, ABSPATH . 'wp-content/plugins/'. $plugin_name))
+                    {
+                        \WP_CLI::success("Symlink created for ".$plugin_name);
+
+                        /* If extra args were given (like --activate) */
+                        if(sizeof($assoc_args)>0)
+                        {
+                            /* They cannot be handled here because when we create symlink, WP DB is not updated to
+                            say "hey, plugin is installed" so we will get an error when trying to do another action (ie: --activate)
+                            because WordPress believe plugin isn't installed */
+                            \WP_CLI::warning("Extra args (starting with --) are not handled with symlinked plugins, please call specific WPCLI command(s)");
+                        }
+                    }
+                    else /* Error */
+                    {
+                        /* We display an error and exit */
+                        \WP_CLI::error("Error creating symlink for ".$plugin_name, true);
+                    }
+
+                }
+                else /* Plugin is not found in WP image  */
+                {
+                    \WP_CLI::log("No plugin found to create symlink for ". $plugin_name.". Installing it...");
+                    parent::install(array($plugin_name), $assoc_args);
+                }
+
+            }
+            else /* Plugin is already installed */
+            {
+                /* We call parent function to do remaining things if needed*/
+                parent::install(array($plugin_name), $assoc_args);
+            }
+
+        } /* END looping through given plugins */
+    }
+}
+
+/* We override existing commands with extended one */
+\WP_CLI::add_command( 'plugin', 'EPFL_WPCLI\EPFL_Plugin_Command' );


### PR DESCRIPTION
Extension de la commande  `wp plugin install` afin qu'elle puisse créer un symlink sur `/wp/wp-content/plugins/<pluginName>`. Pour faire ceci, on surcharge la méthode `install` de la classe `Plugin_Command`.

Si on passe des paramètres supplémentaires à la commande (comme `--activate` par exemple), ceux-ci ne pourront pas être pris en compte. Pourquoi ? parce que lorsque WPCLI se charge, il charge aussi la liste et l'état des plugins. Si on créé un symlink pour simuler l'installation d'un nouveau plugin, la liste des plugins installés n'est pas mis à jour donc on ne peut pas ensuite appeler la méthode d'installation parente (`Plugin_Command::install()`) afin qu'elle termine le job car elle sortira une erreur disant que le plugin n'est pas installé.
*Workaround:* Exécuter l'équivalent du `--activate` via `wp plugin activate ...` après avoir fait le `wp plugin install` du plugin symlinké.

Je n'ai volontairement pas cherché plus pour faire en sorte que cette liste de plugin installés soit mise à jour (et que l'on puisse ensuite appeler la méthode parente pour finir le boulot) car ça impliquerait d'aller beaucoup plus profondément dans le code WPCLI pour surcharger les choses et on deviendrait donc très dépendant de celui-ci, sous-entendu qu'il faudrait recontrôler le package courant à chaque fois qu'on met WPCLI à jour... La décision de rester tel quel, avec cette mini contrainte de devoir ré-exécuter une 2e commande a donc été prise.