### PR TITLE
`wp core symlink` functionality

### DIFF
--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -2,6 +2,7 @@
 
 namespace EPFL_WP_CLI;
 
+define("EPFL_WP_IMAGE_PATH", "/wp/");
 
 /**
  * Manage WordPress Core installation with symlinks

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -11,8 +11,7 @@ define("EPFL_WP_IMAGE_PATH", "/wp/");
  * https://github.com/wp-cli/core-command/blob/master/src/Core_Command.php
  *
  */
-class EPFL_Core_Command extends \Core_Command   {
-
+class EPFL_Core_Command extends \Core_Command {
     /* If enabled, we'll keep a copy of original files/folders */
     var $DEBUG = false;
     var $ORIGINAL_FILES_FOLDERS_SUFFIX = "_old";
@@ -204,9 +203,9 @@ class EPFL_Core_Command extends \Core_Command   {
      *
      * Note: If the current directory doesn't contain a wp-config.php file, then --path flag must be used.
      *
-     * EXAMPLES
+     * ## EXAMPLES
      *
-     * wp --path=$PWD core symlink
+     *     wp --path=$PWD core symlink
      *
      * @when before_wp_load
      */

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -169,46 +169,8 @@ class EPFL_Core_Command extends \Core_Command   {
         /* If install has been correctly done and WordPress image is present,  */
         if(is_blog_installed() && file_exists(EPFL_WP_IMAGE_PATH))
         {
-            $to_symlink = array(
-                /* Files */
-                "wp-cron.php",
-                "wp-load.php",
-                "wp-login.php",
-                "wp-settings.php",
-                /* Folders*/
-                "wp-includes"
-                );
-
-
             /****** 1. Symlinks creation ******/
-
-            \WP_CLI::debug("---- Creating symlinks ----");
-
-
-            foreach($to_symlink as $symlink)
-            {
-                $site_element       = ABSPATH. $symlink;
-                $image_element      = EPFL_WP_IMAGE_PATH.$symlink;
-
-                \WP_CLI::debug("Processing $site_element -> $image_element");
-
-                if(!file_exists($image_element))
-                {
-                    \WP_CLI::warning("Image element doesn't exists (".$image_element."), skipping site symlink procedure", true);
-
-                    return;
-                }
-
-                /* We rename file/folder if requested, or delete it */
-                $this->delete_or_copy_original_file_folder($site_element, true);
-
-                if(!symlink($image_element, $site_element))
-                {
-                    \WP_CLI::error("Cannot create symlink from '".$site_element."' to '".$image_element."'", true);
-                }
-
-            }
-
+            $this->symlink();
 
             /****** 2. Files modifications  ******/
 
@@ -234,8 +196,56 @@ class EPFL_Core_Command extends \Core_Command   {
                                              "table_prefix = 'wp_';\n".
                                              "define('WP_CONTENT_DIR', '".ABSPATH."wp-content');", $wp_config_content);
             $this->update_file_content($wp_config, $wp_config_content);
+        }
+    }
+
+    /**
+     * Make symlinks to /wp if available.
+     *
+     * Note: If the current directory doesn't contain a wp-config.php file, then --path flag must be used.
+     *
+     * EXAMPLES
+     *
+     * wp --path=$PWD core symlink
+     *
+     * @when before_wp_load
+     */
+    public function symlink ($args, $assoc_args) {
+        $to_symlink = array(
+                /* Files */
+                "wp-cron.php",
+                "wp-load.php",
+                "wp-login.php",
+                "wp-settings.php",
+                /* Folders*/
+                "wp-includes"
+                );
 
 
+        \WP_CLI::debug("---- Creating symlinks ----");
+
+
+        foreach($to_symlink as $symlink)
+        {
+            $site_element       = ABSPATH. $symlink;
+            $image_element      = EPFL_WP_IMAGE_PATH.$symlink;
+
+            \WP_CLI::debug("Processing $site_element -> $image_element");
+
+            if(!file_exists($image_element))
+            {
+                \WP_CLI::warning("Image element doesn't exists (".$image_element."), skipping site symlink procedure", true);
+
+                return;
+            }
+
+            /* We rename file/folder if requested, or delete it */
+            $this->delete_or_copy_original_file_folder($site_element, true);
+
+            if(!symlink($image_element, $site_element))
+            {
+                \WP_CLI::error("Cannot create symlink from '".$site_element."' to '".$image_element."'", true);
+            }
         }
     }
 }

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -84,7 +84,7 @@ class EPFL_Core_Command extends \Core_Command   {
         {
             if(!unlink($path))
             {
-                \WP_CLI::error("Cannot delete '".$path."'", true);
+                \WP_CLI::warning("Cannot delete '".$path."'", true);
             }
         }
         else /* We have to delete a directory */


### PR DESCRIPTION
- Needs `@when before_wp_load` sigil to work ([documented here](https://make.wordpress.org/cli/handbook/commands-cookbook/#docblock-tags))
- Requires `--path=` flag if `wp-config.php` doesn't already exist
- Works when there is nothing at all in the target directory yet
- Also fix missing `EPFL_WP_IMAGE_PATH` symbol
