### PR TITLE
Fix PHP fatal error when calling ->symlink() from ->install()

### DIFF
--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -209,7 +209,7 @@ class EPFL_Core_Command extends \Core_Command {
      *
      * @when before_wp_load
      */
-    public function symlink ($args, $assoc_args) {
+    public function symlink ($args = array(), $assoc_args = array()) {
         $to_symlink = array(
                 /* Files */
                 "wp-cron.php",


### PR DESCRIPTION
Sorry for not testing this in #3 