### PR TITLE
Add --nosymlink option

### DIFF
--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -168,12 +168,12 @@ class EPFL_Core_Command extends \Core_Command {
 
         $no_symlink = false;
 		
-		if(array_key_exists('nosymlink', $assoc_args))
-		{
-			$no_symlink = true;
+        if(array_key_exists('nosymlink', $assoc_args))
+        {
+            $no_symlink = true;
 
-			/* We remove param to avoid errors when calling parent func */
-			unset($assoc_args['nosymlink']);
+            /* We remove param to avoid errors when calling parent func */
+            unset($assoc_args['nosymlink']);
         }
         
         /* We first call parent install function to proceed to basic install */

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -133,6 +133,10 @@ class EPFL_Core_Command extends \Core_Command {
 	 *
 	 * ## OPTIONS
 	 *
+     * [--nosymlink]
+	 * : If set, plugin is installed by copying/downloading files instead of creating a symlink 
+	 * if exists in WP image
+     * 
 	 * --url=<url>
 	 * : The address of the new site.
 	 *
@@ -162,11 +166,23 @@ class EPFL_Core_Command extends \Core_Command {
 	 */
     public function install( $args, $assoc_args ) {
 
+        $no_symlink = false;
+		
+		if(array_key_exists('nosymlink', $assoc_args))
+		{
+			$no_symlink = true;
+
+			/* We remove param to avoid errors when calling parent func */
+			unset($assoc_args['nosymlink']);
+        }
+        
         /* We first call parent install function to proceed to basic install */
         parent::install($args, $assoc_args);
 
-        /* If install has been correctly done and WordPress image is present,  */
-        if(is_blog_installed() && file_exists(EPFL_WP_IMAGE_PATH))
+        /* If install has been correctly done 
+        AND we can use symlinks 
+        AND WordPress image is present,  */
+        if(is_blog_installed() && !$no_symlink && file_exists(EPFL_WP_IMAGE_PATH))
         {
             /****** 1. Symlinks creation ******/
             $this->symlink();

--- a/src/EPFL_MUPlugin_Command.php
+++ b/src/EPFL_MUPlugin_Command.php
@@ -128,12 +128,12 @@ class EPFL_MUPlugin_Command  {
 
         $no_symlink = false;
 		
-		if(array_key_exists('nosymlink', $assoc_args))
-		{
-			$no_symlink = true;
+        if(array_key_exists('nosymlink', $assoc_args))
+        {
+            $no_symlink = true;
 
-			/* We remove param to avoid errors when calling parent func */
-			unset($assoc_args['nosymlink']);
+            /* We remove param to avoid errors when calling parent func */
+            unset($assoc_args['nosymlink']);
         }
         
         /* Looping through mu-plugins to install */

--- a/src/EPFL_Theme_Command.php
+++ b/src/EPFL_Theme_Command.php
@@ -57,13 +57,13 @@ class EPFL_Theme_Command extends \Theme_Command  {
 
         $no_symlink = false;
 		
-		if(array_key_exists('nosymlink', $assoc_args))
-		{
-			$no_symlink = true;
+        if(array_key_exists('nosymlink', $assoc_args))
+        {
+        $no_symlink = true;
 
-			/* We remove param to avoid errors when calling parent func */
-			unset($assoc_args['nosymlink']);
-		}
+            /* We remove param to avoid errors when calling parent func */
+            unset($assoc_args['nosymlink']);
+        }
 
         /* Looping through themes to install */
         foreach ($args as $theme_name )

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -4,7 +4,7 @@
  *
  * @author  Lucien Chaboudez <lucien.chaboudez@epfl.ch>
  * @package epfl-idevelop/wp-cli
- * @version 1.0.0
+ * @version 1.0.1
  */
 
 namespace EPFL_WP_CLI;


### PR DESCRIPTION
Ajout d'une option `--nosymlink` pour les commandes d'installation de :
- core
- theme
- plugin 
- mu-plugin

Celle-ci permet d'effectuer une installation sans les symlinks, ce qui est encore nécessaire dans notre cas pour les sites unmanaged.

A noter que j'ai voulu mettre `--no-symlink` car plus "propre" mais WP-CLI me transforme ça en `--symlink` et du coup me dit que c'est pas une option valable... bref, vu que c'est que cosmétique, pas voulu chercher plus longtemps le pourquoi du comment de la chose.