### PR TITLE
Add possibility to specify wpversion

### DIFF
--- a/src/EPFL_MUPlugin_Command.php
+++ b/src/EPFL_MUPlugin_Command.php
@@ -66,15 +66,23 @@ class EPFL_MUPlugin_Command  {
 
             /* If we can use symlinks AND
              file/folder is available in WP image */
-            if(!$no_symlink && ($wp_image_mu_plugin_file_or_folder = path_in_image('mu-plugins', $file_or_folder))!==false)
+            if(!$no_symlink && path_in_image('mu-plugins', $file_or_folder)!==false)
             {
+                /* Saving current working directory and changing to go into directory where WordPress is installed. 
+                This will be then easier to create symlinks  */
+                $current_wd = getcwd();
+                chdir(ABSPATH.'wp-content/mu-plugins/');
+
                 /* Creating symlink to "simulate" mu-plugin installation */
-                if(!symlink($wp_image_mu_plugin_file_or_folder, $target_file_or_folder_path))
+                if(!symlink("../../wp/wp-content/mu-plugins/".$file_or_folder, $file_or_folder))
                 {
                     \WP_CLI::error("Error creating symlink for ".$file_or_folder, true);
                 }
 
                 \WP_CLI::success("Symlink created for ".$file_or_folder);
+
+                /* Going back to original working directory  */
+                chdir($current_wd);
 
             }
             else /* file/folder is not part of WP image */

--- a/src/EPFL_Plugin_Command.php
+++ b/src/EPFL_Plugin_Command.php
@@ -11,9 +11,6 @@ namespace EPFL_WP_CLI;
  */
 class EPFL_Plugin_Command extends \Plugin_Command  {
 
-    /* Some plugins may be available in image but we have to install them from WordPress repo instead */
-    var $DONT_USE_VERSION_FROM_IMAGE = array("polylang");
-
     /**
 	 * Install one or more plugins. If found in WP image, a symlink is created.
 	 *
@@ -119,11 +116,8 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
 
                 $extracted_plugin_name = extract_name_from_package($plugin_name);
 
-				/* If plugin is available in WP image 
-				AND is not in the "don't use" list 
-				AND we can create symlinks */
+				/* If plugin is available in WP image AND we can create symlinks */
                 if(path_in_image('plugins', $extracted_plugin_name)!==false &&
-				   !in_array($extracted_plugin_name, $this->DONT_USE_VERSION_FROM_IMAGE) && 
 				   !$no_symlink)
                 {
                     /* We change URL by plugin short name so it will installed as symlink below */

--- a/src/EPFL_Plugin_Command.php
+++ b/src/EPFL_Plugin_Command.php
@@ -146,11 +146,15 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
 
 				/* If plugin is available in WP image 
 				AND we can create symlinks */
-                if(!$no_symlink && ($wp_image_plugin_folder = path_in_image('plugins', $plugin_name))!==false)
-                {
+                if(!$no_symlink &&  path_in_image('plugins', $plugin_name)!==false)                {
+
+					/* Saving current working directory and changing to go into directory where WordPress is installed. 
+					This will be then easier to create symlinks  */
+					$current_wd = getcwd();
+					chdir(ABSPATH.'wp-content/plugins/');
 
                     /* Creating symlink to "simulate" plugin installation */
-                    if(symlink($wp_image_plugin_folder, ABSPATH . 'wp-content/plugins/'. $plugin_name))
+                    if(symlink("../../wp/wp-content/plugins/".$plugin_name, $plugin_name))
                     {
                         \WP_CLI::success("Symlink created for ".$plugin_name);
 
@@ -167,7 +171,10 @@ class EPFL_Plugin_Command extends \Plugin_Command  {
                     {
                         /* We display an error and exit */
                         \WP_CLI::error("Error creating symlink for ".$plugin_name, true);
-                    }
+					}
+
+					/* Going back to original working directory  */
+					chdir($current_wd);
 
                 }
                 else /* Plugin is not found in WP image  */

--- a/src/EPFL_Theme_Command.php
+++ b/src/EPFL_Theme_Command.php
@@ -100,10 +100,15 @@ class EPFL_Theme_Command extends \Theme_Command  {
 
                 /* If theme is available in WP image
                 AND we can create symlinks */
-                if(!$no_symlink && ($wp_image_theme_folder = path_in_image('themes', $theme_name)) !== false)
+                if(!$no_symlink && path_in_image('themes', $theme_name) !== false)
                 {
+                    /* Saving current working directory and changing to go into directory where WordPress is installed. 
+					This will be then easier to create symlinks  */
+					$current_wd = getcwd();
+                    chdir(ABSPATH.'wp-content/themes/');
+                    
                     /* Creating symlink to "simulate" theme installation */
-                    if(symlink($wp_image_theme_folder, ABSPATH . 'wp-content/themes/'. $theme_name))
+                    if(symlink("../../wp/wp-content/themes/".$theme_name, $theme_name))
                     {
                         \WP_CLI::success("Symlink created for ".$theme_name);
 
@@ -121,6 +126,9 @@ class EPFL_Theme_Command extends \Theme_Command  {
                         /* We display an error and exit */
                         \WP_CLI::error("Error creating symlink for ".$theme_name, true);
                     }
+
+                    /* Going back to original working directory  */
+					chdir($current_wd);
 
                 }
                 else /* Theme is not found in WP image  */

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -4,7 +4,7 @@
  *
  * @author  Lucien Chaboudez <lucien.chaboudez@epfl.ch>
  * @package epfl-idevelop/wp-cli
- * @version 1.0.1
+ * @version 1.0.2
  */
 
 namespace EPFL_WP_CLI;
@@ -14,14 +14,12 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 if ( version_compare( PHP_VERSION, '5.5', '<' ) ) {
-    WP_CLI::error( sprintf( 'This WP-CLI package requires PHP version %s or higher.', '5.5' ) );
+  \WP_CLI::error( sprintf( 'This WP-CLI package requires PHP version %s or higher.', '5.5' ) );
 }
 if ( version_compare( WP_CLI_VERSION, '1.5.0', '<' ) ) {
-    WP_CLI::error( sprintf( 'This WP-CLI package requires WP-CLI version %s or higher. Please visit %s', '1.5.0', 'https://wp-cli.org/#updating' ) );
+  \WP_CLI::error( sprintf( 'This WP-CLI package requires WP-CLI version %s or higher. Please visit %s', '1.5.0', 'https://wp-cli.org/#updating' ) );
 }
 
-
-define('EPFL_WP_IMAGE_WP_CONTENT_PATH', '/wp/wp-content/');
 
 /**
   * To tell if package is remote
@@ -30,7 +28,7 @@ define('EPFL_WP_IMAGE_WP_CONTENT_PATH', '/wp/wp-content/');
   */
 function is_remote_package($package)
 {
-    return (false !== strpos( $package, '://' ));
+  return (false !== strpos( $package, '://' ));
 }
 
 
@@ -41,7 +39,7 @@ function is_remote_package($package)
   */
 function is_zip_package($package)
 {
-    return pathinfo( $package, PATHINFO_EXTENSION ) === 'zip' && is_file( $package );
+  return pathinfo( $package, PATHINFO_EXTENSION ) === 'zip' && is_file( $package );
 }
 
 
@@ -53,7 +51,7 @@ function is_zip_package($package)
   */
 function extract_name_from_package($package)
 {
-    return preg_replace("/(\..+)+/", "", basename($package));
+  return preg_replace("/(\..+)+/", "", basename($package));
 }
 
 
@@ -65,8 +63,8 @@ function extract_name_from_package($package)
   */
 function path_in_image($wp_content_relative_folder, $element)
 {
-    $path = EPFL_WP_IMAGE_WP_CONTENT_PATH. $wp_content_relative_folder ."/" . $element;
-    return file_exists($path)?$path:false;
+  $path = ABSPATH . "wp/wp-content/" . $wp_content_relative_folder . "/" . $element;
+  return file_exists($path)?$path:false;
 }
 
 


### PR DESCRIPTION
- Ajout de la possibilité de sélectionner la version à installer mais UNIQUEMENT dans le cas où on symlink l'installation.
- On peut donner une version majeure (4, 5), ou une version "complète" (5.2.2) mais dans tous les cas, il faut que celle-ci soit présente dans l'image (/wp) pour que ça fonctionne. Sinon, le code part en erreur
- Si on donne un no de version complet (5.2.2), le code va regarder s'il y a un lien avec le no de version majeure et s'il pointe sur la version complète demandée (si `/wp/5 -> /wp/5.2.2`). Si c'est le cas, on va utiliser `wp -> /wp/5` et non pas `wp -> /wp/5.2.2`. Ceci permettra de plus facilement upgrade la version de WordPress dans l'image en faisant pointe `/wp/5` sur une autre.
- Modification de la manière de gérer les install symlinkées pour ne plus faire pointer sur `/wp/4` mais maintenant créer (par défaut) un lien `wp -> /wp/4` et faire pointer les fichier sur `wp` (ex: `wp-load.php -> wp/wp-load.php`). 
- Suppression de la "black list" des plugins à ne pas symlink. C'est maintenant géré au sein de "jahia2wp.py" via un paramètre dans le fichier YAML de configuration du plugin (voir PR https://github.com/epfl-idevelop/jahia2wp/pull/1076)

**NOTES**
- Cette PR peut fonctionner sans problème car paramètres optionnels.
- Une PR dans "jahia2wp" va permettre d'ajouter le paramètre sur la version à l'utilisation des commandes `generate*` (https://github.com/epfl-idevelop/jahia2wp/pull/1076)
