### PR TITLE
Feature: ability to start with `wp core symlink`

### DIFF
--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -315,24 +315,24 @@ class EPFL_Core_Command extends \Core_Command {
         chdir($current_wd);
     }
 
-    private function ensure_symlink ($from, $to, $remove_if_needed=FALSE) {
-        if (@readlink($to) === $from) {
-            \WP_CLI::debug("$to is already a symlink to $from");
+    private function ensure_symlink ($target, $symlink_path, $remove_if_needed=FALSE) {
+        if (@readlink($symlink_path) === $target) {
+            \WP_CLI::debug("$symlink_path is already a symlink to $target");
             return TRUE;
         }
         if ($remove_if_needed) {
             $operation = null;
-            if (@readlink($to)) {
-                $operation = "unlink() symlink $to";
-                $success = unlink($to);
-            } elseif (is_dir($to)) {
-                $operation = "rmdir($to)";
-                $success = rmdir($to);
-            } else if (is_file($to)) {
-                $operation = "unlink($to)";
-                $success = unlink($to);
-            } else if (file_exists($to)) {
-                \WP_CLI::warning("Unable to determine type of $to: " .
+            if (@readlink($symlink_path)) {
+                $operation = "unlink() symlink $symlink_path";
+                $success = unlink($symlink_path);
+            } elseif (is_dir($symlink_path)) {
+                $operation = "rmdir($symlink_path)";
+                $success = rmdir($symlink_path);
+            } else if (is_file($symlink_path)) {
+                $operation = "unlink($symlink_path)";
+                $success = unlink($symlink_path);
+            } else if (file_exists($symlink_path)) {
+                \WP_CLI::warning("Unable to determine type of $symlink_path: " .
                                  posix_strerror(posix_get_last_error()));
                 return FALSE;
             }
@@ -345,9 +345,9 @@ class EPFL_Core_Command extends \Core_Command {
                 }
             }
         }
-        \WP_CLI::debug("symlink($from, $to)");
-        if (! symlink($from, $to)) {
-            \WP_CLI::warning("Cannot symlink($from, $to): " . posix_strerror(posix_get_last_error()));
+        \WP_CLI::debug("symlink($target, $symlink_path)");
+        if (! symlink($target, $symlink_path)) {
+            \WP_CLI::warning("Cannot symlink($target, $symlink_path): " . posix_strerror(posix_get_last_error()));
             return FALSE;
         }
         return TRUE;

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -224,7 +224,7 @@ class EPFL_Core_Command extends \Core_Command {
         if(is_blog_installed() && !$no_symlink)
         {
             /****** 1. Symlinks creation ******/
-            $this->symlink(array('path_to_version' => $path_to_version));
+            $this->symlink(array(), array('path_to_version' => $path_to_version));
 
             /****** 2. Files modifications  ******/
 
@@ -282,9 +282,9 @@ class EPFL_Core_Command extends \Core_Command {
         \WP_CLI::debug("---- Creating symlinks ----");
 
         /* We first create symlink to access desired version */
-        if(!symlink($args['path_to_version'], ABSPATH."wp"))
+        if(!symlink($assoc_args['path_to_version'], ABSPATH."wp"))
         {
-            \WP_CLI::error("Cannot create symlink on WP image '".$args['path_to_version']."'", true);
+            \WP_CLI::error("Cannot create symlink on WP image '".$assoc_args['path_to_version']."'", true);
         }
 
         /* Saving current working directory and changing to go into directory where WordPress is installed. 


### PR DESCRIPTION
Make it so
```
wp --path=. core symlink --path_to_version="/wp/5.2"
```
works out of an empty directory.

- When `wp core install` calls `->symlink()`, use same calling convention (i.e. `$assoc_args`) as the WP-CLI argument parser does
- Refactor to make the symlinking robust in a variety of situations e.g.: symlink already exists (and points to the correct place, or not), file exists, (empty) directory exists
 