### PR TITLE
Fix remove dir if not empty during symlinking

### DIFF
--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -315,6 +315,25 @@ class EPFL_Core_Command extends \Core_Command {
         chdir($current_wd);
     }
 
+
+    private function rm_dir($dir) 
+    {
+        $files = array_diff(scandir($dir), array('.','..'));
+         foreach ($files as $file) 
+         {
+           if(is_dir("$dir/$file"))
+           {
+               $this->rm_dir("$dir/$file");
+           }
+           else
+           {
+               unlink("$dir/$file");
+           }
+         }
+         return rmdir($dir);
+    }
+
+
     private function ensure_symlink ($target, $symlink_path, $remove_if_needed=FALSE) {
         if (@readlink($symlink_path) === $target) {
             \WP_CLI::debug("$symlink_path is already a symlink to $target");
@@ -326,8 +345,8 @@ class EPFL_Core_Command extends \Core_Command {
                 $operation = "unlink() symlink $symlink_path";
                 $success = unlink($symlink_path);
             } elseif (is_dir($symlink_path)) {
-                $operation = "rmdir($symlink_path)";
-                $success = rmdir($symlink_path);
+                $operation = "this->rm_dir($symlink_path)";
+                $success = $this->rm_dir($symlink_path);
             } else if (is_file($symlink_path)) {
                 $operation = "unlink($symlink_path)";
                 $success = unlink($symlink_path);

--- a/src/EPFL_Core_Command.php
+++ b/src/EPFL_Core_Command.php
@@ -51,7 +51,7 @@ class EPFL_Core_Command extends \Core_Command {
         }
         else /* We're not debugging so we delete the file */
         {
-            $this->delete_file_folder($source);
+            $this->delete_recursively_file_folder($source);
         }
     }
 
@@ -77,7 +77,7 @@ class EPFL_Core_Command extends \Core_Command {
     }
 
     /* Deletes a file or folder and handles errors */
-    private function delete_file_folder($path)
+    private function delete_recursively_file_folder($path)
     {
         /* If we have to delete a file */
         if (!is_dir($path))
@@ -86,6 +86,7 @@ class EPFL_Core_Command extends \Core_Command {
             {
                 \WP_CLI::warning("Cannot delete '".$path."'", true);
             }
+            return false;
         }
         else /* We have to delete a directory */
         {
@@ -105,12 +106,12 @@ class EPFL_Core_Command extends \Core_Command {
                     }
                     else
                     {
-                         $this->delete_file_folder($path.'/'.$file);
+                         $this->delete_recursively_file_folder($path.'/'.$file);
                     }
                 }
             }
             closedir($dir_handle);
-            rmdir($path);
+            return rmdir($path);
         }
     }
 
@@ -316,22 +317,6 @@ class EPFL_Core_Command extends \Core_Command {
     }
 
 
-    private function rm_dir($dir) 
-    {
-        $files = array_diff(scandir($dir), array('.','..'));
-         foreach ($files as $file) 
-         {
-           if(is_dir("$dir/$file"))
-           {
-               $this->rm_dir("$dir/$file");
-           }
-           else
-           {
-               unlink("$dir/$file");
-           }
-         }
-         return rmdir($dir);
-    }
 
 
     private function ensure_symlink ($target, $symlink_path, $remove_if_needed=FALSE) {
@@ -345,8 +330,8 @@ class EPFL_Core_Command extends \Core_Command {
                 $operation = "unlink() symlink $symlink_path";
                 $success = unlink($symlink_path);
             } elseif (is_dir($symlink_path)) {
-                $operation = "this->rm_dir($symlink_path)";
-                $success = $this->rm_dir($symlink_path);
+                $operation = "this->delete_recursively_file_folder($symlink_path)";
+                $success = $this->delete_recursively_file_folder($symlink_path);
             } else if (is_file($symlink_path)) {
                 $operation = "unlink($symlink_path)";
                 $success = unlink($symlink_path);

--- a/src/epfl-wp-cli.php
+++ b/src/epfl-wp-cli.php
@@ -4,7 +4,7 @@
  *
  * @author  Lucien Chaboudez <lucien.chaboudez@epfl.ch>
  * @package epfl-idevelop/wp-cli
- * @version 1.0.2
+ * @version 1.0.3
  */
 
 namespace EPFL_WP_CLI;


### PR DESCRIPTION
L'appel à `rmdir()` fonctionne uniquement lorsque l'on créé un site depuis `new-wp-site`. 
Si le site est créé via `wp core install` puis on appelle la fonction `symlink()` cela lève un `Warning` lors de l'appel à `rmdir()` parce qu'aucun des dossiers n'est vide... Et ceci fait donc planter la création du site.

Appel de la fonction (déjà présente) permettant d'effacer un dossier complet (récursivement) afin que le job se fasse correctement.