### PR TITLE
Fix the method signature "delete" on theme commands

### DIFF
--- a/src/EPFL_Theme_Command.php
+++ b/src/EPFL_Theme_Command.php
@@ -174,7 +174,7 @@ class EPFL_Theme_Command extends \Theme_Command  {
 	 *
 	 * @alias uninstall
 	 */
-    public function delete( $args )
+    public function delete( $args,  $assoc_args )
     {
         /* Looping through themes to install */
         foreach ( $this->fetcher->get_many( $args ) as $theme )


### PR DESCRIPTION
We got some warning when deleting a theme : 
PHP Warning:  Declaration of EPFL_WP_CLI\EPFL_Theme_Command::delete($args) should be compatible with Theme_Command::delete($args, $assoc_args) in /var/www/.wp-cli/packages/vendor/epfl-si/wp-cli/src/EPFL_Theme_Command.php on line 177

This PR aim fix this change https://github.com/wp-cli/extension-command/commit/3004a20a9aa1793294b7805b6f7e26c9ec31aa78